### PR TITLE
Remove work-around for pyxtuml qualified constant issue

### DIFF
--- a/CarPark/models/CarPark/Components/CarparkControl/CarparkControl/ChargeSegment/ChargeSegment.xtuml
+++ b/CarPark/models/CarPark/Components/CarparkControl/CarparkControl/ChargeSegment/ChargeSegment.xtuml
@@ -23,8 +23,7 @@ select one Linear related by FeeSched->Linear[R21.''employs''];
 // If this is a linear fee schedule, calculate the charge using 
 // the linear rate and then apply any minimum or maximum fees if they exist.
 if ( not empty Linear )
-  // self.Amount = Linear.Rate * (self.Duration / TimeConversion::QuantumPerHour); https://github.com/xtuml/pyxtuml/issues/20  @TODO
-  self.Amount = Linear.Rate * (self.Duration / QuantumPerHour);
+  self.Amount = Linear.Rate * (self.Duration / TimeConversion::QuantumPerHour);
   select one MinimumFee related by Linear->FlatFee[R18.''employs minimum''];
   if ( not empty MinimumFee ) 
     if ( MinimumFee.Amount > self.Amount )

--- a/CarPark/models/CarPark/Components/CarparkControl/CarparkControl/Payment/InstanceStateMachine/InstanceStateMachine.xtuml
+++ b/CarPark/models/CarPark/Components/CarparkControl/CarparkControl/Payment/InstanceStateMachine/InstanceStateMachine.xtuml
@@ -173,8 +173,7 @@ select any charge related by self->Stay[R16.''retires debt for'']->
   ChargeSegment[R15]->
   Charge[R23.''addend of''];
 CurrentTime = TIM::current_seconds();
-// charge.ExitDeadline = CurrentTime + (15 * TimeConversion::QuantumPerMinute); https://github.com/xtuml/pyxtuml/issues/20  @TODO
-charge.ExitDeadline = CurrentTime + (15 * QuantumPerMinute);
+charge.ExitDeadline = CurrentTime + (15 * TimeConversion::QuantumPerMinute);
 select one PaymentMachine related by self->PaymentMachine[R25.''collected by''];
 generate PaymentMachine7:ExitDeadline to PaymentMachine;
 


### PR DESCRIPTION
Fixes #31.
Nominal bucket runs successfully with Ciera-generated code.