### PR TITLE
Complete, works in Verifier and Ciera-generated code

### DIFF
--- a/CarPark/models/CarPark/Components/CarparkControl/CarparkControl.xtuml
+++ b/CarPark/models/CarPark/Components/CarparkControl/CarparkControl.xtuml
@@ -1450,6 +1450,24 @@ INSERT INTO C_EP_PROXY
 	'ReturnedTicket',
 	'',
 	'../../Interfaces/PaymentMachine/PaymentMachine.xtuml');
+INSERT INTO SPR_PEP
+	VALUES ("48d305d2-e5fd-4826-b828-7c9feb17c602",
+	"7d98badf-0872-49ac-a66e-72a2d0d07fa7",
+	"beb17c01-5d43-4cbd-bd44-08536daaf245");
+INSERT INTO SPR_PS
+	VALUES ("48d305d2-e5fd-4826-b828-7c9feb17c602",
+	'ExitDeadline',
+	'',
+	'',
+	3,
+	0);
+INSERT INTO C_EP_PROXY
+	VALUES ("7d98badf-0872-49ac-a66e-72a2d0d07fa7",
+	"1775761d-746e-41ae-a5e0-cd1a783dc665",
+	-1,
+	'ExitDeadline',
+	'',
+	'../../Interfaces/PaymentMachine/PaymentMachine.xtuml');
 INSERT INTO C_I_PROXY
 	VALUES ("1775761d-746e-41ae-a5e0-cd1a783dc665",
 	"00000000-0000-0000-0000-000000000000",

--- a/CarPark/models/CarPark/Components/CarparkControl/CarparkControl/Payment/InstanceStateMachine/InstanceStateMachine.xtuml
+++ b/CarPark/models/CarPark/Components/CarparkControl/CarparkControl/Payment/InstanceStateMachine/InstanceStateMachine.xtuml
@@ -175,7 +175,7 @@ select any charge related by self->Stay[R16.''retires debt for'']->
 CurrentTime = TIM::current_seconds();
 charge.ExitDeadline = CurrentTime + (15 * TimeConversion::QuantumPerMinute);
 select one PaymentMachine related by self->PaymentMachine[R25.''collected by''];
-generate PaymentMachine7:ExitDeadline to PaymentMachine;
+generate PaymentMachine7:ExitDeadline( Deadline:charge.ExitDeadline ) to PaymentMachine;
 
 // Unlink from the payment machine.
 unrelate self from PaymentMachine across R25.''collected by'';',

--- a/CarPark/models/CarPark/Components/CarparkControl/CarparkControl/PaymentMachine/InstanceStateMachine/InstanceStateMachine.xtuml
+++ b/CarPark/models/CarPark/Components/CarparkControl/CarparkControl/PaymentMachine/InstanceStateMachine/InstanceStateMachine.xtuml
@@ -14,7 +14,7 @@ INSERT INTO SM_EVTDI
 	"c7a393ee-03dc-44d0-a142-8335736b4fbd",
 	'TicketNumber',
 	'',
-	"ba5eda7a-def5-0000-0000-000000000003",
+	"ba5eda7a-def5-0000-0000-000000000002",
 	'',
 	"f6eb4fef-6b00-47ac-89ca-0be2f159952f",
 	"00000000-0000-0000-0000-000000000000");
@@ -26,6 +26,15 @@ INSERT INTO SM_EVTDI
 	"ba5eda7a-def5-0000-0000-000000000003",
 	'',
 	"99ecc7a8-9c49-49b7-a07d-1e29a675688f",
+	"00000000-0000-0000-0000-000000000000");
+INSERT INTO SM_EVTDI
+	VALUES ("e9fe2f89-64c4-4383-b927-2c50dea8a1bf",
+	"c7a393ee-03dc-44d0-a142-8335736b4fbd",
+	'Deadline',
+	'',
+	"ba5eda7a-def5-0000-0000-000000000002",
+	'',
+	"5b109579-96e4-406a-800b-ad8441d51927",
 	"00000000-0000-0000-0000-000000000000");
 INSERT INTO SM_LEVT
 	VALUES ("f6eb4fef-6b00-47ac-89ca-0be2f159952f",
@@ -857,7 +866,8 @@ INSERT INTO SM_ACT
 	VALUES ("14e95daa-9724-4ce1-b7cd-721ac55413b0",
 	"c7a393ee-03dc-44d0-a142-8335736b4fbd",
 	1,
-	'// @TODO Print exit deadline on ticket.',
+	'// Print exit deadline on ticket.
+send Payer::ExitDeadline( Deadline:param.Deadline );',
 	'',
 	0);
 INSERT INTO GD_MD

--- a/CarPark/models/CarPark/Interfaces/PaymentMachine/PaymentMachine.xtuml
+++ b/CarPark/models/CarPark/Interfaces/PaymentMachine/PaymentMachine.xtuml
@@ -200,6 +200,27 @@ INSERT INTO C_PP
 	0,
 	'',
 	"00000000-0000-0000-0000-000000000000");
+INSERT INTO C_EP
+	VALUES ("7d98badf-0872-49ac-a66e-72a2d0d07fa7",
+	"1775761d-746e-41ae-a5e0-cd1a783dc665",
+	-1,
+	'ExitDeadline',
+	'');
+INSERT INTO C_AS
+	VALUES ("7d98badf-0872-49ac-a66e-72a2d0d07fa7",
+	'ExitDeadline',
+	'',
+	1,
+	"ab99ffd4-de35-47a9-9eb4-ee31927071ec");
+INSERT INTO C_PP
+	VALUES ("561db48f-dfa7-4487-b2a3-f41f0ab780ed",
+	"7d98badf-0872-49ac-a66e-72a2d0d07fa7",
+	"ba5eda7a-def5-0000-0000-000000000002",
+	'Deadline',
+	'',
+	0,
+	'',
+	"00000000-0000-0000-0000-000000000000");
 INSERT INTO PE_PE
 	VALUES ("1775761d-746e-41ae-a5e0-cd1a783dc665",
 	1,

--- a/InteractiveTesting/models/InteractiveTesting/Components/InteractiveTestbench/InteractiveTestbench.xtuml
+++ b/InteractiveTesting/models/InteractiveTesting/Components/InteractiveTestbench/InteractiveTestbench.xtuml
@@ -1390,6 +1390,24 @@ INSERT INTO C_EP_PROXY
 	'ReturnedTicket',
 	'',
 	'../../../../../CarPark/models/CarPark/Interfaces/PaymentMachine/PaymentMachine.xtuml');
+INSERT INTO SPR_REP
+	VALUES ("1182eb10-476e-49ad-8c0d-3593c32daea4",
+	"7d98badf-0872-49ac-a66e-72a2d0d07fa7",
+	"258032a0-84e8-437b-9e3f-3f82e9d440ed");
+INSERT INTO SPR_RS
+	VALUES ("1182eb10-476e-49ad-8c0d-3593c32daea4",
+	'ExitDeadline',
+	'',
+	'',
+	3,
+	0);
+INSERT INTO C_EP_PROXY
+	VALUES ("7d98badf-0872-49ac-a66e-72a2d0d07fa7",
+	"1775761d-746e-41ae-a5e0-cd1a783dc665",
+	-1,
+	'ExitDeadline',
+	'',
+	'../../../../../CarPark/models/CarPark/Interfaces/PaymentMachine/PaymentMachine.xtuml');
 INSERT INTO C_I_PROXY
 	VALUES ("1775761d-746e-41ae-a5e0-cd1a783dc665",
 	"00000000-0000-0000-0000-000000000000",


### PR DESCRIPTION
Fixes #30.
This commit also adds an interface message carrying the exit deadline to
the payment machine, so the payment machine can print the exit deadline
on the ticket before returning it to the patron.