### PR TITLE
Complete

### DIFF
--- a/CarParkTestbench/models/CarParkTestbench/Components/CarParkTestbench/CarParkTestbench.xtuml
+++ b/CarParkTestbench/models/CarParkTestbench/Components/CarParkTestbench/CarParkTestbench.xtuml
@@ -2005,7 +2005,11 @@ INSERT INTO SPR_RS
 	VALUES ("90f9ea74-8479-448f-8e6d-e5990e8c3ec4",
 	'DeleteStimulus',
 	'Signals the testbench that the identified stimulus sub/supertype can be disposed of.',
-	'',
+	'select any stimulus from instances of Stimulus
+ where ( selected.stimulusId == param.stimulusId );
+if ( not_empty stimulus )
+  stimulus.Delete();
+end if;',
 	1,
 	0);
 INSERT INTO C_EP_PROXY
@@ -2023,7 +2027,11 @@ INSERT INTO SPR_RS
 	VALUES ("cf649e9c-fad9-4dde-8425-b7516843a14e",
 	'DeleteTestBucket',
 	'Signals the testbench that the identified test bucket sub/supertype can be disposed of.',
-	'',
+	'select any bucket from instances of TestBucket
+ where ( selected.bucketId == param.bucketId );
+if ( not_empty bucket )
+  bucket.Delete();
+end if;',
 	1,
 	0);
 INSERT INTO C_EP_PROXY
@@ -2059,7 +2067,11 @@ INSERT INTO SPR_RS
 	VALUES ("9ed0e418-1457-4e21-a7fc-a6bfc4be7086",
 	'DeleteObservation',
 	'Signals the testbench that the identified observation sub/supertype can be disposed of.',
-	'',
+	'select any observation from instances of Observation
+ where ( selected.observationId == param.observationId );
+if ( not_empty observation )
+  observation.Delete();
+end if;',
 	1,
 	0);
 INSERT INTO C_EP_PROXY

--- a/CarParkTestbench/models/CarParkTestbench/Components/CarParkTestbench/Testbench/Observation/Observation.xtuml
+++ b/CarParkTestbench/models/CarParkTestbench/Components/CarParkTestbench/Testbench/Observation/Observation.xtuml
@@ -183,7 +183,9 @@ INSERT INTO O_TFR
 	'Dispose of the client instances when the test sequence service no longer needs them.',
 	"ba5eda7a-def5-0000-0000-000000000000",
 	1,
-	'select one req related by self->QueryTicketRequest[R4];
+	'// one of these subtypes should match...
+
+select one req related by self->QueryTicketRequest[R4];
 if ( not_empty req )
   unrelate req from self across R4;
   delete object instance req;
@@ -202,6 +204,16 @@ select one bv related by self->BalanceValue[R4];
 if ( not_empty bv )
   unrelate bv from self across R4;
   delete object instance bv;
+end if;
+select one giveback related by self->TicketReturned[R4];
+if ( not_empty giveback )
+  unrelate giveback from self across R4;
+  delete object instance giveback;
+end if;
+select one amount related by self->ChangeDispensed[R4];
+if ( not_empty amount )
+  unrelate amount from self across R4;
+  delete object instance amount;
 end if;
 
 delete object instance self;',

--- a/CarParkTestbench/models/CarParkTestbench/Components/CarParkTestbench/Testbench/Stimulus/Stimulus.xtuml
+++ b/CarParkTestbench/models/CarParkTestbench/Components/CarParkTestbench/Testbench/Stimulus/Stimulus.xtuml
@@ -102,28 +102,37 @@ INSERT INTO O_TFR
 	'Dispose of the client instances when the test sequence service no longer needs them.',
 	"ba5eda7a-def5-0000-0000-000000000000",
 	1,
-	'select one ff related by self->FastForward[R3];
-if ( not_empty ff )
-  unrelate ff from self across R3;
-  delete object instance ff;
-else
-  select one va related by self->VehicleArrived[R3];
-  if ( not_empty va )
-  	unrelate va from self across R3;
-  	delete object instance va;
-  else
-  	select one tt related by self->TicketTaken[R3];
-  	if ( not_empty tt )
-  	  unrelate tt from self across R3;
-  	  delete object instance tt;
-    else
-      select one vd related by self->VehicleDeparture[R3];
-      if ( not_empty vd )
-        unrelate vd from self across R3; 
-        delete object instance vd;
-      end if;
-  	end if;
-  end if;
+	'// One of these subtypes should match...
+
+select one fastforward related by self->FastForward[R3];
+if ( not_empty fastforward )
+  unrelate fastforward from self across R3;
+  delete object instance fastforward;
+end if;
+select one arrival related by self->VehicleArrived[R3];
+if ( not_empty arrival )
+  unrelate arrival from self across R3;
+  delete object instance arrival;
+end if;
+select one ticket related by self->TicketRequested[R3];
+if ( not_empty ticket )
+  unrelate ticket from self across R3;
+  delete object instance ticket;
+end if;
+select one take related by self->TicketTaken[R3];
+if ( not_empty take )
+  unrelate take from self across R3;
+  delete object instance take;
+end if;
+select one insert related by self->TicketInserted[R3];
+if ( not_empty insert )
+  unrelate insert from self across R3;
+  delete object instance insert;
+end if;
+select one departure related by self->VehicleDeparture[R3];
+if ( not_empty departure )
+  unrelate departure from self across R3; 
+  delete object instance departure;
 end if;
 delete object instance self;',
 	1,


### PR DESCRIPTION
Follow deletion signals for Observation, Stimulus, TestBucket:
navigate to subtype; unrelate; delete; delete supertype.
Visually tested in Verifier/Session Explorer.
Fixes #105