### PR TITLE
Complete

### DIFF
--- a/CarParkTestbench/models/CarParkTestbench/Components/CarParkTestbench/CarParkTestbench.xtuml
+++ b/CarParkTestbench/models/CarParkTestbench/Components/CarParkTestbench/CarParkTestbench.xtuml
@@ -2450,6 +2450,41 @@ INSERT INTO C_EP_PROXY
 	'SetObservationTimeResolutions',
 	'Observations inherit default resolutions from the sequence they are added to; these can be overridden.',
 	'../../../../../TestFramework/models/TestFramework/Interfaces/TestSequencing/TestSequencing.xtuml');
+INSERT INTO SPR_REP
+	VALUES ("acdb853b-055f-4d49-b234-3cedd6e22356",
+	"2e275a42-594f-477a-86c9-6a263a8b1e41",
+	"90ea7117-8b0f-4f98-a679-70202e1c75cf");
+INSERT INTO SPR_RS
+	VALUES ("acdb853b-055f-4d49-b234-3cedd6e22356",
+	'TestCaseComplete',
+	'Signal completion of a test case.',
+	'if ( param.success )
+  LOG::LogSuccess( message:"Test case " + param.caseLabel + " passed." );
+else
+  LOG::LogFailure( message:"Test case " + param.caseLabel + " failed." );
+end if;
+LOG::LogInfo( message:" ------------------------------ ");
+select many reqests from instances of ReceivedTicketRequest;
+for each request in reqests
+  delete object instance request;
+end for;
+select many occs from instances of Occupancy;
+for each occ in occs
+  delete object instance occ;
+end for;
+select many bcmds from instances of BarrierCommand;
+for each bcmd in bcmds
+  delete object instance bcmd;
+end for;',
+	1,
+	0);
+INSERT INTO C_EP_PROXY
+	VALUES ("2e275a42-594f-477a-86c9-6a263a8b1e41",
+	"eff7aa83-70b9-46a6-bfc0-08d66d36431e",
+	-1,
+	'TestCaseComplete',
+	'Signal completion of a test case.',
+	'../../../../../TestFramework/models/TestFramework/Interfaces/TestSequencing/TestSequencing.xtuml');
 INSERT INTO C_I_PROXY
 	VALUES ("eff7aa83-70b9-46a6-bfc0-08d66d36431e",
 	"00000000-0000-0000-0000-000000000000",

--- a/CarParkTestbench/models/CarParkTestbench/Components/CarParkTestbench/TestFunctions/TestFunctions.xtuml
+++ b/CarParkTestbench/models/CarParkTestbench/Components/CarParkTestbench/TestFunctions/TestFunctions.xtuml
@@ -109,6 +109,24 @@ INSERT INTO PE_PE
 	"68e29e87-70d2-4c06-97db-6b293da075ca",
 	"00000000-0000-0000-0000-000000000000",
 	1);
+INSERT INTO S_SYNC
+	VALUES ("ba2c6c34-50e4-41f5-a78a-952638baf966",
+	"00000000-0000-0000-0000-000000000000",
+	'RunEscapeCases',
+	'',
+	'send TESTSEQ::RegisterTestSuite( suiteLabel:"CarPark Escape Test Suite", keepAllCases:False ); 
+EscapeCaseBucket::AddBucketToSuite();
+send Operator::OpenCarpark();',
+	"ba5eda7a-def5-0000-0000-000000000000",
+	1,
+	'',
+	0);
+INSERT INTO PE_PE
+	VALUES ("ba2c6c34-50e4-41f5-a78a-952638baf966",
+	1,
+	"68e29e87-70d2-4c06-97db-6b293da075ca",
+	"00000000-0000-0000-0000-000000000000",
+	1);
 INSERT INTO PE_PE
 	VALUES ("68e29e87-70d2-4c06-97db-6b293da075ca",
 	1,

--- a/CarParkTestbench/models/CarParkTestbench/Components/CarParkTestbench/Testbench/EscapeCaseBucket/EscapeCaseBucket.xtuml
+++ b/CarParkTestbench/models/CarParkTestbench/Components/CarParkTestbench/Testbench/EscapeCaseBucket/EscapeCaseBucket.xtuml
@@ -24,7 +24,6 @@ send TESTSEQ::SetTestBucketTimeResolutions( bucketId:bucket.bucketId, timeResolu
 // This will require stimuli and observations which represent interaction with the Operator.
 
 send TESTSEQ::AddTestCase( caseLabel:"Overstay" ); 
-send TESTSEQ::LinkRequirement( reqPrefix:"CP", reqNumber:33, caseLabel:"Overstay" );
 send TESTSEQ::AddStimulusSequence( seqLabel:"seq01" );
 FastForward::Create( seqLabel:"seq01", hours:1, minutes:42, seconds:0 );
 VehicleArrived::Create( seqLabel:"seq01", location:"North", stand:"Entry" );
@@ -57,10 +56,10 @@ INSERT INTO O_TFR
 	'Configure the Test Suite to include this bucket''s set of test cases when run.',
 	"ba5eda7a-def5-0000-0000-000000000000",
 	0,
-	'create object instance failures of DemonstrationCaseBucket;
+	'create object instance escapes of EscapeCaseBucket;
 create object instance bucket of TestBucket;
-bucket.name = "Demonstration cases";
-relate failures to bucket across R700;
+bucket.name = "Escape cases";
+relate escapes to bucket across R700;
 bucket.AddToSuite();',
 	1,
 	'',
@@ -73,8 +72,8 @@ INSERT INTO O_TFR
 	'Execute the set of tests in this bucket stand-alone.',
 	"ba5eda7a-def5-0000-0000-000000000000",
 	0,
-	'send TESTSEQ::RegisterTestSuite( suiteLabel:"CarPark Demonstration Test Suite", keepAllCases:False ); 
-DemonstrationCaseBucket::AddBucketToSuite();
+	'send TESTSEQ::RegisterTestSuite( suiteLabel:"CarPark Escape Test Suite", keepAllCases:False ); 
+EscapeCaseBucket::AddBucketToSuite();
 send Operator::OpenCarpark();',
 	1,
 	'',

--- a/CarParkTestbench/models/CarParkTestbench/Components/CarParkTestbench/Testbench/QueryTicketRequest/QueryTicketRequest.xtuml
+++ b/CarParkTestbench/models/CarParkTestbench/Components/CarParkTestbench/Testbench/QueryTicketRequest/QueryTicketRequest.xtuml
@@ -71,18 +71,14 @@ INSERT INTO O_TFR
 select one observation related by self->Observation[R400]; 
 
 select any request from instances of ReceivedTicketRequest
- where ( selected.location == self.location );
+ where ( selected.location == self.location )
+ and ( selected.enabled == self.enabled );
 if ( not_empty request )
-  if ( request.enabled == self.enabled )
-    observation.Complete( success:True );
-  else
-    observation.Complete( success:False );
-  end if;
+  observation.Complete( success:True );
+  delete object instance request;
 else
   observation.Complete( success:False );
-end if;
-delete object instance request;
-',
+end if;',
 	1,
 	'',
 	"03babdb5-d972-403b-bd28-cf8322b92453",

--- a/CarParkTestbench/models/CarParkTestbench/Components/CarParkTestbench/Testbench/TestBucket/TestBucket.xtuml
+++ b/CarParkTestbench/models/CarParkTestbench/Components/CarParkTestbench/Testbench/TestBucket/TestBucket.xtuml
@@ -83,6 +83,10 @@ end if;
 select one failures related by self->DemonstrationCaseBucket[R700];
 if ( not_empty failures )
   failures.CreateBucketTests();
+end if;
+select one escapes related by self->EscapeCaseBucket[R700];
+if ( not_empty escapes )
+  escapes.CreateBucketTests();
 end if;',
 	1,
 	'',


### PR DESCRIPTION
Clean up instances which escaped observation - on receipt of
TestCaseComplete from framework.
Tested with Carpark in Verifier.
Also, fixed missing test function for EscapeCaseBucket; fixed contents.
Fixes #127.