### PR TITLE
Use Ciera 2.4.0

### DIFF
--- a/CarParkTestbench/pom.xml
+++ b/CarParkTestbench/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>io.ciera</groupId>
       <artifactId>runtime</artifactId>
-      <version>2.3.1</version>
+      <version>2.4.0</version>
     </dependency>
     <dependency>
       <groupId>org.xtuml</groupId>
@@ -137,7 +137,7 @@
       <plugin>
         <groupId>io.ciera</groupId>
         <artifactId>ciera-maven-plugin</artifactId>
-        <version>2.3.1</version>
+        <version>2.4.0</version>
         <executions>
           <execution>
             <id>pre-build</id>

--- a/Deployment/pom.xml
+++ b/Deployment/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>io.ciera</groupId>
       <artifactId>runtime</artifactId>
-      <version>2.3.1</version>
+      <version>2.4.0</version>
     </dependency>
     <dependency>
       <groupId>org.xtuml</groupId>
@@ -157,7 +157,7 @@
       <plugin>
         <groupId>io.ciera</groupId>
         <artifactId>ciera-maven-plugin</artifactId>
-        <version>2.3.1</version>
+        <version>2.4.0</version>
         <executions>
           <execution>
             <id>pre-build</id>

--- a/InteractiveTesting/pom.xml
+++ b/InteractiveTesting/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>io.ciera</groupId>
       <artifactId>runtime</artifactId>
-      <version>2.3.1</version>
+      <version>2.4.0</version>
     </dependency>
     <dependency>
       <groupId>org.xtuml</groupId>
@@ -132,7 +132,7 @@
       <plugin>
         <groupId>io.ciera</groupId>
         <artifactId>ciera-maven-plugin</artifactId>
-        <version>2.3.1</version>
+        <version>2.4.0</version>
         <executions>
           <execution>
             <id>pre-build</id>


### PR DESCRIPTION
Updated pom files to use Ciera release 2.4.0.  Tested all three
configurations:  clients, automated test, and interactive test.